### PR TITLE
[FND-1] - fixed typo in urls at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ run the presentation, though the rake task should handle this already.
 Two URLs are available:
 
 * http://localhost:9090 - "student" view of the slides
-* http://localhost:9090 - "presenter view of the slides
+* http://localhost:9090/presenter - "presenter" view of the slides
 
 When presenting the materials as an instructor, use the "presenter"
 view. This will also pop up a second browser window that will advance


### PR DESCRIPTION
This is a minor typo in the README file about the urls availables. Both urls are the same at the description but they aren't.

A [ticked](http://tickets.opscode.com/browse/FND-1) is been filed for this just to follow the recomentations.

Thanks
