### PR TITLE
wrong GLI version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source :rubygems
 gem "rake"
 gem "redcarpet"
 gem "pdfkit"
-gem "showoff", :git => "git://github.com/jtimberman/showoff.git", :branch => "chef-fnd"
+gem "showoff", :git => "https://github.com/schacon/showoff.git"
 gem "chef", "~> 0.10.0"
 gem "knife-ec2"
+gem "gli", "1.6.0"


### PR DESCRIPTION
Hi,

I tried to use the slides, however when I ran it out of the box, 'rake present' refused to start, because GLI was complaining about GLI.run being run differently in GLI 2.0 (saying to either fix the application or use the latest from GLI 1.x). When I downgraded GLI to 1.6, it was complaining that GLI 2.0 is required.

The fix attached gets the slides to run correctly (I've got it from gsandie)
