### PR TITLE
Gemfile updates: "source" + "git@" url

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
-source :rubygems
+source 'https://rubygems.org'
 gem "rake"
 gem "redcarpet"
 gem "pdfkit"
-gem "showoff", :git => "git://github.com/jtimberman/showoff.git", :branch => "chef-fnd"
+gem "showoff", :git => "git@github.com:jtimberman/showoff.git", :branch => "chef-fnd"
 gem "chef", "~> 0.10.0"
 gem "knife-ec2"


### PR DESCRIPTION
- Eliminates warning for `source` not being HTTPS-based.
- Uses `git@` rather than `git://` URL for fetching `showoff` as those are not supported by GitHub any more.
